### PR TITLE
Add Segment Open Fellowship to grant examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [Dat](https://usopendata.org/)
 * [Andrey Petrov + Stripe Open-Source Retreat and urllib3](https://medium.com/@shazow/urllib3-stripe-and-open-source-grants-edb9c0e46e82#.45ylnxrh4)
 * [Django + Mozilla Open Source Support](https://www.djangoproject.com/weblog/2015/dec/11/django-awarded-moss-grant/)
+* [Segment Open Fellowship](https://segment.com/blog/segment-open-fellowship-2017/)
 
 ## Consulting & services
 


### PR DESCRIPTION
Segment just announced an open source fellowship that looks similar to Stripe's.

Adding to the list, as there are such few examples of corporate grants :tada: