### PR TITLE
Add ChatSecure to donation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [Twisted](https://twistedmatrix.com/trac/wiki/WhyDonate)
 * [Git](https://git-scm.com/sfc)
 * [Transmission](https://www.transmissionbt.com/)
+* [ChatSecure](https://chatsecure.org/blog/sustainable-open-source-starts-with-you/)
 
 ## Bounties
 


### PR DESCRIPTION
ChatSecure started experimenting with a donation button, to find independence from grant funding:

https://chatsecure.org/blog/sustainable-open-source-starts-with-you/

Adding them as an example.