### PR TITLE
Add Caddy case study

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [Mesosphere](https://mesosphere.com/)
 * [Phusion Passenger](https://www.phusionpassenger.com/)
 * [Sidekiq](http://sidekiq.org/)
+* [Caddy](https://caddyserver.com/blog/accouncing-caddy-commercial-licenses); see also [retrospective](https://caddy.community/t/the-realities-of-being-a-foss-maintainer/2728/7)
 
 ## Foundations & consortiums
 


### PR DESCRIPTION
Caddy recently announced a commercial license offering. mholt did a thorough retrospective that I think is useful for others to learn from.

I've listed Caddy under "open core" because its source code is Apache 2.0 no matter what, but its binaries require  a commercial license if you are a company. I think that's the right category!