### PR TITLE
Adds Gitcoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 
 #### Case Studies
 
+* [Gitcoin](https://gitcoin.co/explorer)
 * [Bountysource](http://bountysource.com)
 * [Internet Bug Bounty](https://internetbugbounty.org/)
 * [Google Patch Rewards](https://www.google.com/about/appsecurity/patch-rewards/)


### PR DESCRIPTION
Adds Gitcoin to the list of projects that support bounties -- We recently announced support for several pilot projects like Metamask and Truffle, and have thousands of dollars of open issues on the system.