### PR TITLE
Add License Zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 
 * [Fair Source](https://fair.io/), used by [Sourcegraph](https://sourcegraph.com/)
 * [BSL (Business Source License)](https://mariadb.com/bsl-faq-adopting), used by [MariaDB](https://mariadb.com/)
+* [License Zero](https://medium.com/licensezero/the-license-zero-manifesto-fecb7aaf4c0a)
 
 
 ## Dual License


### PR DESCRIPTION
Adding [License Zero](https://medium.com/licensezero/the-license-zero-manifesto-fecb7aaf4c0a) as a type of freemium/"shared source" license, which has come up multiple times in conversations these days.