### PR TITLE
Add Varnish Moral License

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 
 #### Case Studies
 
+* [Varnish Moral License](http://phk.freebsd.dk/VML/)
 * [Neighbourhoodie](https://neighbourhood.ie/)
 * [Baroque Software](http://baroquesoftware.com/)
 * [OpenSSL](http://openssl.com/what.html)


### PR DESCRIPTION
Adds the [Varnish Moral License](http://phk.freebsd.dk/VML/), with the blessing of Poul-Henning Kamp https://twitter.com/bsdphk/status/935148193733644288

This is a funny one I came across awhile ago, but never added (see Twitter thread re: why). It's called a "license", but really it's a company sponsorship masquerading as a contract/invoice. Definitely worth a look!