### PR TITLE
Add note about adoption to freemium licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 
 * Not actually open source
 * Still a new area of exploration (though related to the [shareware](https://en.wikipedia.org/wiki/Shareware) movement), not well proven
+* Charging for use may negatively impact adoption
 
 #### Case Studies
 


### PR DESCRIPTION
I find this is one of the cons I refer to the most when discussing freemium licenses: in part, open source is popular because it costs nothing. Charging for use could suppress user adoption.