### PR TITLE
Add Flattr to recurring crowdfunding services list

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 #### Pros
 
 * Few strings attached
-* Can be easier for an individual to legally manage via, e.g. [Patreon](https://patreon.com), [Salt](https://salt.bountysource.com/), [Liberapay](https://liberapay.com/), [OpenCollective](https://opencollective.com)
+* Can be easier for an individual to legally manage via, e.g. [Patreon](https://patreon.com), [Salt](https://salt.bountysource.com/), [Liberapay](https://liberapay.com/), [OpenCollective](https://opencollective.com), [Flattr](https://flattr.com/)
 
 #### Cons
 


### PR DESCRIPTION
[Flattr](https://flattr.com/creators) isn’t quite one-time nor recurring, but somewhere in between. Developers can link their GitHub accounts and domains to Flattr, and receive a share of Flattr users’ monthly contribution based on whether people visited their GitHub project pages and domains.