### PR TITLE
Add Metafizzy to dual license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 
 * [MySQL](http://www.mysql.com/about/legal/licensing/oem/)
 * [SQLite](https://www.sqlite.org/copyright.html)
+* Metafizzy: [Isotope](https://isotope.metafizzy.co/license.html), [Flickity](https://flickity.metafizzy.co/license.html), etc.
 
 ## Open core
 


### PR DESCRIPTION
Found this example [in the wild](https://twitter.com/desandro/status/954435191782694913). @desandro says:

> Hi! This is how I’ve run @metafizzyco for past 7 years. I got lucky and was able to switch to full-time OSS after 3 years

The docs around Metafizzy's commercial licenses are pretty comprehensive, so recommend checking it out for anyone who's interested in a dual licensing model.