### PR TITLE
Update information on Ungit

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [Fair Source](https://fair.io/), used by [Sourcegraph](https://sourcegraph.com/)
 * [BSL (Business Source License)](https://mariadb.com/bsl-faq-adopting), used by [MariaDB](https://mariadb.com/)
 * [License Zero](https://medium.com/licensezero/the-license-zero-manifesto-fecb7aaf4c0a)
-* [Faircode](https://faircode.io), used by [Ungit](https://github.com/FredrikNoren/ungit)
+* [Ungit switched back from Faircode to MIT License](https://github.com/FredrikNoren/ungit/issues/997)
 
 
 ---


### PR DESCRIPTION
Ungit switched back from Faircode to MIT License. See https://github.com/FredrikNoren/ungit/issues/997.

I thought, this is worth to be still noticed as "case study" and thus, I changed the link text and the link.