### PR TITLE
Add Phusion Passenger conference talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [Docker](https://www.docker.com/)
 * [Elastic](https://www.elastic.co/)
 * [Mesosphere](https://mesosphere.com/)
-* [Phusion Passenger](https://www.phusionpassenger.com/)
+* [Phusion Passenger](https://www.phusionpassenger.com/); see also their talk, ["Bootstrapping a Business Around Open Source"](https://www.youtube.com/watch?v=uHaMpLyMOL0&feature=youtu.be) (video)
 * [Sidekiq](http://sidekiq.org/)
 * [Caddy](https://caddyserver.com/blog/accouncing-caddy-commercial-licenses); see also [retrospective](https://caddy.community/t/the-realities-of-being-a-foss-maintainer/2728/7)
 * [GitLab](https://about.gitlab.com/)


### PR DESCRIPTION
I came across this conference talk from another repo (https://github.com/nayafia/awesome-maintainers/pull/18).

It's super good! Only 15 min long and very practical insights from Phusion Passenger's maintainers, `@FooBarWidget` and `@prototype`. Recommend checking it out if you're trying to monetize an open source project.