### PR TITLE
Add Signal Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [Ruby Together](http://rubytogether.org/)
 * [Python Software Foundation](https://www.python.org/psf/)
 * [Node.js Foundation](https://www.sitepoint.com/goodbye-joyent-hello-node-js-foundation/)
+* [Signal Foundation](https://signal.org/blog/signal-foundation/)
 
 ## Venture capital
 


### PR DESCRIPTION
Signal recently announced the creation of a $50M foundation to support their ongoing development, thanks to Brian Acton (cofounder of WhatsApp).

> We’ve always wanted to do much more, and our limitations have often been challenging. Over the lifetime of the project, there have only been an average of 2.3 full-time software developers, and the entire Signal team has never been more than 7 people.

https://signal.org/blog/signal-foundation/