### PR TITLE
Add Monero's funding proposal system

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [Andrew Godwin + Django (personal effort)](https://www.kickstarter.com/projects/andrewgodwin/schema-migrations-for-django)
 * [ribasushi + CPAN (personal effort)](https://www.tilt.com/tilts/year-of-ribasushi-help-him-focus-on-cpan-for-2016)
 * [RESTful WP-CLI](https://poststatus.com/kickstarter-open-source-project/)
+* [Monero Forum Funding System (FFS)](https://getmonero.org/forum-funding-system/)
 
 ## Crowdfunding (recurring)
 


### PR DESCRIPTION
Came across this example in a [Medium post](https://medium.com/@dhsue/an-analysis-of-monero-governance-3f8bef770b29). Monero's community members can request funding to work on the project, using a public proposal system.

[Here's an example](https://getmonero.org/forum-funding-system/proposals/documentation-cleanup.html) of someone who was funded to improve Monero's documentation.

h/t [Derek Hsue](https://twitter.com/derek_hsue) for flagging!