### PR TITLE
Add Prism as example of paid support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,10 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 
 #### Case Studies
 
-* [Vue.js](https://www.patreon.com/evanyou)
-* [MochaJS](https://opencollective.com/mochajs)
-* [React-boilerplate](https://opencollective.com/react-boilerplate)
+* [Evan You + Vue.js Patreon](https://www.patreon.com/evanyou)
+* [Eran Hammer + hapi Patreon](https://www.patreon.com/eranhammer)
+* [webpack](https://opencollective.com/webpack)
+* [Babel](https://opencollective.com/babel)
 * [GnuPG](https://www.gnupg.org/donate/index.html)
 * [Tom Christie + Django REST framework (personal effort)](https://fund.django-rest-framework.org/topics/funding/)
 * [Ruby Together](https://rubytogether.org)
@@ -298,6 +299,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 
 #### Case Studies
 
+* [Prism](https://www.patreon.com/prismlibrary) - supporting their Patreon gives you access to their community Slack channel for project support
 * [Moodle](https://moodle.org/)
 * [Forge Laravel](https://forge.laravel.com/)
 * [Sentry](https://getsentry.com/)


### PR DESCRIPTION
`ghuntley` tipped me off to Prism, which has an interesting perk on their Patreon page. For $1+/month, you get:

> Gives you access to our community Slack channel where you can ask questions and get help from the community and the Prism Library project maintainers (when available).

Apparently, their Slack channel used to be public, but now it is only available to paying Patreon supporters (see [Geoffrey's tweet](https://twitter.com/GeoffreyHuntley/status/990956059492663297)).

Thought this was a cool example of an easy, lightweight way to charge for support, so I've added it to the SaaS section (side note, maybe I should rename that section, or start a separate `Paid Support` section 🤔)

I also updated the `Crowdfunding (recurring)` section a bit to use more canonical examples of successful Patreon/Open Collective campaigns that have emerged in recent years.