### PR TITLE
Add Handshake community grant program

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 
 #### Case Studies
 
+* [Handshake community grant program](https://handshake.org)
 * [Dat](https://usopendata.org/)
 * [Andrey Petrov + Stripe Open-Source Retreat and urllib3](https://medium.com/@shazow/urllib3-stripe-and-open-source-grants-edb9c0e46e82#.45ylnxrh4)
 * [Libraries.io grant applications](https://github.com/librariesio/supporters)


### PR DESCRIPTION
The Handshake project announced yesterday that it raised $10.2M from VCs and angels, all of which will be distributed to free and open source developers: https://handshake.org/

Project recipients include GNOME, Babel, Ruby Together, FreeBSD. Here's GNOME's announcement about their $400K grant: https://twitter.com/gnome/status/1025076048352948224

They're also distributing 70% of their coin supply to FOSS via "faucet", which developers can apply for on the website.

I was pretty psyched to see this. It'll be an interesting experiment to follow!