### PR TITLE
Rename "Dual license" to "Selling exceptions" and expand

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The categories are not mutually exclusive. For example, a project might have a f
 10. [Consulting](#consulting)
 11. [Paid support](#paid-support)
 12. [SaaS](#saas)
-13. [Selling exceptions](#selling-exceptions)
+13. [Copyleft + paid license](#copyleft--paid-license)
 14. [Open core](#open-core)
 15. [Foundations & consortiums](#foundations--consortiums)
 16. [Venture capital](#venture-capital)
@@ -331,7 +331,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [Ghost](https://ghost.org/about/)
 * [GitLab](https://gitlab.com) (also uses open core licensing)
 
-## Selling exceptions
+## Copyleft + paid license
 
 *Companies selling proprietary software prefer to include permissively licensed code (such as MIT or Apache 2.0) rather than copyleft licensed code (like the GPL) in their software, because the latter requires them to keep the same copyleft terms for their end products. So, some open source projects use a copyleft license by default, but they sell license exceptions, proprietary licenses, or permissive commercial licenses to companies who want to bypass the copyleft requirements.*
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The categories are not mutually exclusive. For example, a project might have a f
 10. [Consulting](#consulting)
 11. [Paid support](#paid-support)
 12. [SaaS](#saas)
-13. [Dual license](#dual-license)
+13. [Selling exceptions](#selling-exceptions)
 14. [Open core](#open-core)
 15. [Foundations & consortiums](#foundations--consortiums)
 16. [Venture capital](#venture-capital)
@@ -331,9 +331,9 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [Ghost](https://ghost.org/about/)
 * [GitLab](https://gitlab.com) (also uses open core licensing)
 
-## Dual License
+## Selling exceptions
 
-*Companies prefer to include permissively licensed code (such as MIT or Apache 2.0) rather than copyleft licensed code (like the GPL) in their software, because the latter requires them to keep the same copyleft terms for their end products. So, some open source projects use a dual-license approach: the default project license is copyleft, but they sell either proprietary or permissive commercial licenses to companies who want to bypass the copyleft requirements.*
+*Companies selling proprietary software prefer to include permissively licensed code (such as MIT or Apache 2.0) rather than copyleft licensed code (like the GPL) in their software, because the latter requires them to keep the same copyleft terms for their end products. So, some open source projects use a copyleft license by default, but they sell license exceptions, proprietary licenses, or permissive commercial licenses to companies who want to bypass the copyleft requirements.*
 
 #### Pros
 


### PR DESCRIPTION
"Dual license" normally means something different, namely releasing one project under two or more licenses simultaneously, often for broader compatibility with other Open Source licenses. For instance, the Rust project is dual-licensed under MIT and Apache 2.0. "Dual license" doesn't normally describe the business model of selling *separate* alternative non-copyleft licenses.

Expand the text a bit, to clarify what kinds of companies might purchase such exceptions (not *all* companies prefer non-copyleft), and to allow for other legal structures in doing so.