### PR TITLE
Add OSS Capital

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 
 #### Case Studies
 
+* [OSS Capital](https://oss.capital/)
 * [Npm](http://blog.npmjs.org/post/76320673650/funding)
 * [Confluent](http://www.confluent.io/blog/confluent-raises-a-series-b-funding)
 * [NodeSource](https://techcrunch.com/2015/02/09/nodesource-raises-3-million-to-build-new-programming-tools/)


### PR DESCRIPTION
`josephjacks` [recently announced](https://twitter.com/asynchio/status/1046792188850397184) the formation of a venture fund, [OSS Capital](https://oss.capital/), focused exclusively on funding commercial open source projects:

> The world's first and only commercial OSS-founder-backed and founded exclusively focused on investing in + supporting commercial OSS founders