### PR TITLE
Add Grin General Fund - community crowdfunding

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [ribasushi + CPAN (personal effort)](https://www.tilt.com/tilts/year-of-ribasushi-help-him-focus-on-cpan-for-2016)
 * [RESTful WP-CLI](https://poststatus.com/kickstarter-open-source-project/)
 * [Monero Forum Funding System (FFS)](https://getmonero.org/forum-funding-system/)
-* [Dash Budget Proposal Tracker](https://dashvotetracker.com/)
 
 ## Crowdfunding (recurring)
 
@@ -254,8 +253,10 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 
 #### Case Studies
 
+* [Grin General Fund](http://grin-tech.org/funding.html)
 * [Handshake community grant program](https://handshake.org)
 * [Dat Project](https://blog.datproject.org/2017/09/15/dat-funding-history/)
+* [Dash Budget Proposal Tracker](https://dashvotetracker.com/)
 * [Andrey Petrov + Stripe Open-Source Retreat and urllib3](https://medium.com/@shazow/urllib3-stripe-and-open-source-grants-edb9c0e46e82#.45ylnxrh4)
 * [Libraries.io grant applications](https://github.com/librariesio/supporters)
 * [Django + Mozilla Open Source Support](https://www.djangoproject.com/weblog/2015/dec/11/django-awarded-moss-grant/)


### PR DESCRIPTION
This is an interesting example of a project (Grin) that's [crowdfunding their development](http://grin-tech.org/funding.html) with a recurring "general fund". 

> To keep Grin open and free from controlling influences, the project will attempt to rely 100% on community donations for its funding needs.

Also recommend checking out how they ran a [campaign for Yeastplume](http://grin-tech.org/yeastplume.html), a developer on the project.

They don't have a foundation, instead using multisig wallets + fund developers directly. I've written a few relevant pieces about this [1][2], so cool to find another example in the wild.

[1] Decentralized funding? An analysis of three programs: https://nadiaeghbal.com/grant-programs
[2] Governance without foundations: https://nadiaeghbal.com/foundations