### PR TITLE
Add Fody

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 
 #### Case Studies
 
+* [Fody](https://github.com/Fody/Fody/blob/master/readme.md): Must be a Patreon supporter to open an issue or pull request
 * [Prism](https://www.patreon.com/prismlibrary): Supporting their Patreon gives you access to their community Slack channel for project support
 * [Red Hat](https://en.wikipedia.org/wiki/Red_Hat#Business_model)
 * [Tidelift paid subscriptions](https://tidelift.com/subscription)


### PR DESCRIPTION
Here's another example of a project that is moving to paid support. In order to open an issue or PR, you need to be a Patreon backer:

> When raising an issue or a pull request, the users may be checked against the list of backers, and that issue/PR may be closed without further examination.

I'm very interested in models that charge on the participation side, while keeping the code free for anyone to use.

Tweet announcing the change: https://twitter.com/SimonCropp/status/1069437826972807169

See https://github.com/nayafia/lemonade-stand/pull/82 for prior art