### PR TITLE
Add Inkscape's "funded development" system

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [Andrew Godwin + Django (personal effort)](https://www.kickstarter.com/projects/andrewgodwin/schema-migrations-for-django)
 * [Dave Gandy + Font Awesome](https://www.kickstarter.com/projects/232193852/font-awesome-5)
 * [GDAL Coordinate System Barn Raising](https://gdalbarn.com/)
+* [Inkscape's "funded development" system](https://inkscape.org/support-us/funded-development/)
 * [Michal Papis + Rvm (personal effort)](https://www.bountysource.com/teams/rvm/fundraiser)
 * [Monero Forum Funding System (FFS)](https://getmonero.org/forum-funding-system/)
 * [RESTful WP-CLI](https://poststatus.com/kickstarter-open-source-project/)


### PR DESCRIPTION
This is pretty interesting: https://inkscape.org/support-us/funded-development/

I have no idea how well it works in practice, but they seem to strike a good balance between centralized and decentralized management. Money goes towards funding development work that nobody wants to do *as a volunteer*, and only trusted contributors (those listed in the AUTHORS file) can apply to work on them. Kind of like bounties 2.0.

> This is so that any proposed projects that are fun or easy get done by volunteers, and money can be focused on harder unsexy work

/cc @owocki @coderberry in case it's of interest, made me think of Gitcoin!

Related reading:
- Blog post I wrote last fall about [decentralized funding programs](https://nadiaeghbal.com/grant-programs). Always cool to see how bigger projects handle the governance aspects of funding contributors.