### PR TITLE
Add Markdown Monster

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 
 #### Case Studies
 
+* [Markdown Monster](https://markdownmonster.west-wind.com/): Source code is viewable, but [a license must be purchased](https://markdownmonster.west-wind.com/download.aspx) for continued use. Project contributors are [eligible for a free license](https://markdownmonster.west-wind.com/download.aspx#Contribute).
 * [BSL (Business Source License)](https://mariadb.com/bsl-faq-adopting), used by [MariaDB](https://mariadb.com/)
 * [Fair Source](https://fair.io/), used by [Sourcegraph](https://sourcegraph.com/)
 * [License Zero](https://medium.com/licensezero/the-license-zero-manifesto-fecb7aaf4c0a)

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 
 #### Case Studies
 
-* [Markdown Monster](https://markdownmonster.west-wind.com/): Source code is viewable, but [a license must be purchased](https://markdownmonster.west-wind.com/download.aspx) for continued use. Project contributors are [eligible for a free license](https://markdownmonster.west-wind.com/download.aspx#Contribute).
+* [Markdown Monster](https://markdownmonster.west-wind.com/): Source code is viewable, but [a license must be purchased](https://markdownmonster.west-wind.com/download.aspx) for continued use. Project contributors are [eligible for a free license](https://markdownmonster.west-wind.com/download.aspx#Contribute)
 * [BSL (Business Source License)](https://mariadb.com/bsl-faq-adopting), used by [MariaDB](https://mariadb.com/)
 * [Fair Source](https://fair.io/), used by [Sourcegraph](https://sourcegraph.com/)
 * [License Zero](https://medium.com/licensezero/the-license-zero-manifesto-fecb7aaf4c0a)


### PR DESCRIPTION
Hadn't seen this before! [Markdown Monster](https://markdownmonster.west-wind.com/) is source available (meaning you can view and download the source code), but you are required to purchase a license for continued use.

However, users who make valuable contributions back to the project [qualify for a free license](https://markdownmonster.west-wind.com/download.aspx#Contribute):

> Contributors that provide valuable feedback with quality bug reports or enhancement requests, help out with code via Pull Requests, help promote Markdown Monster, or support Markdown Monster in any other significant way are all eligible for a free license.

I have no idea how this all holds up legally, but thought it was an elegant approach to aligning incentives. h/t @sonyamann for [finding this one](https://twitter.com/sonyaellenmann/status/1111069512021868544)