### PR TITLE
Add Formidable's Sauce program for employees

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [Futurice's open source program](http://futurice.com/blog/sponsoring-free-time-open-source-activities)
 * [Google and Go](https://golang.org/doc/faq#history)
 * [Mozilla and Rust](https://www.rust-lang.org/faq.html#is-this-project-controlled-by-mozilla)
+* [Formidable's Sauce program](https://formidable.com/blog/2019/sauce-program/), where they pay employees for their open source contibutions
 
 
 ## Grants


### PR DESCRIPTION
From their [blog post](https://formidable.com/blog/2019/sauce-program/):

> For the last nine months we’ve experimented with paying our employees for any open source contributions to any project they do on their free time, no strings attached. [...]

> We pay our employees $20/hr for contributions to OSS and tech communities, whether it’s a third-party library we use in our work like React, Next.js, or styled-components; one of our own OSS projects like Spectacle or Urql; or even a personal hack project purely for fun and learning, as long as it’s released under an OSI license. Contributions can be code, documentation, design work, pull request reviews, issue triage, community management, or really anything that the individual thinks counts as a contribution [...]

> During the trial period, 42% of all Formidables (and half of our engineering staff) have been paid for contributions to 55 different OSS projects and local mentorship communities. Our employees have fixed critical bugs in code we use every day, launched new OSS projects, had a lot of fun, and learned a ton!