### PR TITLE
Add examples to advertising section

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [GitFund](https://gitfund.io)
 * [Hoodie](http://hood.ie/sponsoring/)
 * [Read the Docs](http://blog.readthedocs.com/ads-on-read-the-docs/)
+* [Feross's experiment with StandardJS](https://feross.org/funding-experiment-recap/)
+* Kite sponsorship of Minimap ([summary](https://medium.com/@nayafia/the-kite-debacle-is-democracy-at-work-6a04bc043c50))
 
 ## Get hired by a company to work on project
 


### PR DESCRIPTION
Feross recently ran an experiment where he displayed ads to users who installed StandardJS. Adding his [recap](https://feross.org/funding-experiment-recap/) of the experiment here.

It also reminded me of this thing that happened with Kite/Minimap a few years ago, so I added that to the list too. (It's my personal summary of it at the time, which I feel a little weird pointing to, but I'm trying not to link directly to controversial GitHub issues -- even if locked -- to avoid encouraging pile-ons. Happy to change this link to a different summary if someone finds one.)