### PR TITLE
Fix "The bounties network" dead  link

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [Inkscape's "funded development" system](https://inkscape.org/support-us/funded-development/)
 * [Internet Bug Bounty](https://internetbugbounty.org/)
 * [IssueHunt](https://issuehunt.io)
-* [The Bounties Network](https://www.bounties.network/)
+* [The Bounties Network](https://bounties.network/)
 
 ## Sponsorware
 


### PR DESCRIPTION
The bounty Network link in the Bounties section is a dead link, So I've fixed it 