### PR TITLE
Added line item for On-Demand paid support via BookMyTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [Prism](https://www.patreon.com/prismlibrary): Supporting their Patreon gives you access to their community Slack channel for project support
 * [Red Hat](https://en.wikipedia.org/wiki/Red_Hat#Business_model)
 * [Tidelift paid subscriptions](https://tidelift.com/subscription)
+* [BookMyTime](https://bookmytime.dev): Make it easy for users to know that you provide paid On-Demand support and your per hour support charges
 
 ## SaaS
 


### PR DESCRIPTION
Paid Support usually comes in the form of support contracts. This makes it a major decision for open source users which typically use many open source projects together. BookMyTime is a much simpler way for open source maintainers to communicate and provide on-demand support to open source users. We are trying to make it transparent to the open source users if paid support is available for a project and at what price, to make it easy for them to avail this option is a standard way. We also hope that it can become an effective income stream for open source maintainers.

Added a line item for BookMyTime under the paid support option. 