### PR TITLE
Add GitHub Secure Open Source Fund and FLOSS/Fund to Grants section

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,14 +286,14 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [Dash Budget Proposal Tracker](https://dashvotetracker.com/)
 * [Dat Project](https://blog.datproject.org/2017/09/15/dat-funding-history/)
 * [Django + Mozilla Open Source Support](https://www.djangoproject.com/weblog/2015/dec/11/django-awarded-moss-grant/)
+* [FLOSS/Fund](https://floss.fund/)
+* [GitHub Secure Open Source Fund](https://resources.github.com/github-secure-open-source-fund/)
 * [Grin General Fund](http://grin-tech.org/funding.html)
 * [Handshake community grant program](https://handshake.org)
 * [Libraries.io grant applications](https://github.com/librariesio/supporters)
 * [ralphtheninja/open-funding](https://github.com/ralphtheninja/open-funding#grants) has a list of grants
 * [Segment Open Fellowship](https://segment.com/blog/segment-open-fellowship-2017/)
 * [Sentry Open Source Grant](https://blog.sentry.io/2019/01/29/apply-sentry-open-source-grant)
-* [GitHub Secure Open Source Fund](https://resources.github.com/github-secure-open-source-fund/)
-* [FLOSS/Fund](https://floss.fund/)
 
 ## Consulting
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ TRANSLATIONS: [Traditional Chinese(繁體中文)](https://github.com/jserv/lemon
 * [ralphtheninja/open-funding](https://github.com/ralphtheninja/open-funding#grants) has a list of grants
 * [Segment Open Fellowship](https://segment.com/blog/segment-open-fellowship-2017/)
 * [Sentry Open Source Grant](https://blog.sentry.io/2019/01/29/apply-sentry-open-source-grant)
+* [GitHub Secure Open Source Fund](https://resources.github.com/github-secure-open-source-fund/)
+* [FLOSS/Fund](https://floss.fund/)
 
 ## Consulting
 


### PR DESCRIPTION
- https://resources.github.com/github-secure-open-source-fund/
- https://floss.fund/

@nayafia please tell me if it's better to link to one of the FLOSS/fund [update posts](https://floss.fund/blog/update-2025-may/) instead of the https://floss.fund homepage